### PR TITLE
Support allocating shared LB for services

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,15 +33,11 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/throttle"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/inject"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/runtime"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/targetgroupbinding"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/version"
-	corewebhook "sigs.k8s.io/aws-load-balancer-controller/webhooks/core"
-	elbv2webhook "sigs.k8s.io/aws-load-balancer-controller/webhooks/elbv2"
-	networkingwebhook "sigs.k8s.io/aws-load-balancer-controller/webhooks/networking"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -91,7 +87,7 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
-	config.ConfigureWebhookServer(controllerCFG.RuntimeConfig, mgr)
+	//config.ConfigureWebhookServer(controllerCFG.RuntimeConfig, mgr)
 	clientSet, err := kubernetes.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "unable to obtain clientSet")
@@ -149,14 +145,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	podReadinessGateInjector := inject.NewPodReadinessGate(controllerCFG.PodWebhookConfig,
-		mgr.GetClient(), ctrl.Log.WithName("pod-readiness-gate-injector"))
-	corewebhook.NewPodMutator(podReadinessGateInjector).SetupWithManager(mgr)
-	corewebhook.NewServiceMutator(controllerCFG.ServiceConfig.LoadBalancerClass, ctrl.Log).SetupWithManager(mgr)
-	elbv2webhook.NewIngressClassParamsValidator().SetupWithManager(mgr)
-	elbv2webhook.NewTargetGroupBindingMutator(cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
-	elbv2webhook.NewTargetGroupBindingValidator(mgr.GetClient(), cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
-	networkingwebhook.NewIngressValidator(mgr.GetClient(), controllerCFG.IngressConfig, ctrl.Log).SetupWithManager(mgr)
+	//podReadinessGateInjector := inject.NewPodReadinessGate(controllerCFG.PodWebhookConfig,
+	//	mgr.GetClient(), ctrl.Log.WithName("pod-readiness-gate-injector"))
+	//corewebhook.NewPodMutator(podReadinessGateInjector).SetupWithManager(mgr)
+	//corewebhook.NewServiceMutator(controllerCFG.ServiceConfig.LoadBalancerClass, ctrl.Log).SetupWithManager(mgr)
+	//elbv2webhook.NewIngressClassParamsValidator().SetupWithManager(mgr)
+	//elbv2webhook.NewTargetGroupBindingMutator(cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
+	//elbv2webhook.NewTargetGroupBindingValidator(mgr.GetClient(), cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
+	//networkingwebhook.NewIngressValidator(mgr.GetClient(), controllerCFG.IngressConfig, ctrl.Log).SetupWithManager(mgr)
 	//+kubebuilder:scaffold:builder
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -33,11 +33,15 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/throttle"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/inject"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/runtime"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/targetgroupbinding"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/version"
+	corewebhook "sigs.k8s.io/aws-load-balancer-controller/webhooks/core"
+	elbv2webhook "sigs.k8s.io/aws-load-balancer-controller/webhooks/elbv2"
+	networkingwebhook "sigs.k8s.io/aws-load-balancer-controller/webhooks/networking"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -87,7 +91,7 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
-	//config.ConfigureWebhookServer(controllerCFG.RuntimeConfig, mgr)
+	config.ConfigureWebhookServer(controllerCFG.RuntimeConfig, mgr)
 	clientSet, err := kubernetes.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "unable to obtain clientSet")
@@ -145,14 +149,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	//podReadinessGateInjector := inject.NewPodReadinessGate(controllerCFG.PodWebhookConfig,
-	//	mgr.GetClient(), ctrl.Log.WithName("pod-readiness-gate-injector"))
-	//corewebhook.NewPodMutator(podReadinessGateInjector).SetupWithManager(mgr)
-	//corewebhook.NewServiceMutator(controllerCFG.ServiceConfig.LoadBalancerClass, ctrl.Log).SetupWithManager(mgr)
-	//elbv2webhook.NewIngressClassParamsValidator().SetupWithManager(mgr)
-	//elbv2webhook.NewTargetGroupBindingMutator(cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
-	//elbv2webhook.NewTargetGroupBindingValidator(mgr.GetClient(), cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
-	//networkingwebhook.NewIngressValidator(mgr.GetClient(), controllerCFG.IngressConfig, ctrl.Log).SetupWithManager(mgr)
+	podReadinessGateInjector := inject.NewPodReadinessGate(controllerCFG.PodWebhookConfig,
+		mgr.GetClient(), ctrl.Log.WithName("pod-readiness-gate-injector"))
+	corewebhook.NewPodMutator(podReadinessGateInjector).SetupWithManager(mgr)
+	corewebhook.NewServiceMutator(controllerCFG.ServiceConfig.LoadBalancerClass, ctrl.Log).SetupWithManager(mgr)
+	elbv2webhook.NewIngressClassParamsValidator().SetupWithManager(mgr)
+	elbv2webhook.NewTargetGroupBindingMutator(cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
+	elbv2webhook.NewTargetGroupBindingValidator(mgr.GetClient(), cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
+	networkingwebhook.NewIngressValidator(mgr.GetClient(), controllerCFG.IngressConfig, ctrl.Log).SetupWithManager(mgr)
 	//+kubebuilder:scaffold:builder
 
 	go func() {

--- a/pkg/deploy/ec2/security_group_manager.go
+++ b/pkg/deploy/ec2/security_group_manager.go
@@ -2,6 +2,8 @@ package ec2
 
 import (
 	"context"
+	"time"
+
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
@@ -12,7 +14,6 @@ import (
 	ec2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/ec2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/runtime"
-	"time"
 )
 
 const (

--- a/pkg/deploy/ec2/security_group_synthesizer.go
+++ b/pkg/deploy/ec2/security_group_synthesizer.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/pkg/model/core/graph/resource_graph.go
+++ b/pkg/model/core/graph/resource_graph.go
@@ -13,6 +13,8 @@ type ResourceGraph interface {
 	// Add a node into ResourceGraph.
 	AddNode(node ResourceUID)
 
+	RemoveNode(node ResourceUID)
+
 	// Add a edge into ResourceGraph, where dstNode depends on srcNode.
 	AddEdge(srcNode ResourceUID, dstNode ResourceUID)
 
@@ -42,6 +44,24 @@ type defaultResourceGraph struct {
 // Add a node into ResourceGraph.
 func (g *defaultResourceGraph) AddNode(node ResourceUID) {
 	g.nodes = append(g.nodes, node)
+}
+
+func (g *defaultResourceGraph) RemoveNode(node ResourceUID) {
+	for i, n := range g.nodes {
+		if n == node {
+			g.nodes = append(g.nodes[:i], g.nodes[i+1:]...)
+			break
+		}
+	}
+	delete(g.outEdges, node)
+	for _, nodes := range g.outEdges {
+		for i, n := range nodes {
+			if n == node {
+				nodes = append(nodes[:i], nodes[i+1:]...)
+				break
+			}
+		}
+	}
 }
 
 // Add a edge into ResourceGraph, where dstNode depends on srcNode.

--- a/pkg/service/model_build_load_balancer_test.go
+++ b/pkg/service/model_build_load_balancer_test.go
@@ -1431,6 +1431,7 @@ func Test_defaultModelBuildTask_buildLoadBalancerName(t *testing.T) {
 				service:          tt.service,
 				clusterName:      tt.clusterName,
 				annotationParser: annotations.NewSuffixAnnotationParser("service.beta.kubernetes.io"),
+				serviceUtils:     &defaultServiceUtils{},
 			}
 			got, err := task.buildLoadBalancerName(context.Background(), tt.scheme)
 			if err != nil {

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -2,12 +2,16 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"strconv"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
@@ -16,8 +20,10 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core/graph"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -26,6 +32,9 @@ const (
 	LoadBalancerTargetTypeIP       = "ip"
 	LoadBalancerTargetTypeInstance = "instance"
 	lbAttrsDeletionProtection      = "deletion_protection.enabled"
+
+	LoadBalancerAllocatingPortKey = "service.beta.kubernetes.io/aws-load-balancer-allocating-port"
+	LoadBalancerStackKey          = "service.beta.kubernetes.io/aws-load-balancer-stack-name"
 )
 
 // ModelBuilder builds the model stack for the service resource.
@@ -40,7 +49,7 @@ func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver
 	elbv2TaggingManager elbv2deploy.TaggingManager, ec2Client services.EC2, featureGates config.FeatureGates, clusterName string, defaultTags map[string]string,
 	externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string, enableIPTargetType bool, serviceUtils ServiceUtils,
 	backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, enableBackendSG bool,
-	disableRestrictedSGRules bool) *defaultModelBuilder {
+	disableRestrictedSGRules bool, k8sClient client.Client) *defaultModelBuilder {
 	return &defaultModelBuilder{
 		annotationParser:         annotationParser,
 		subnetsResolver:          subnetsResolver,
@@ -61,6 +70,8 @@ func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver
 		ec2Client:                ec2Client,
 		enableBackendSG:          enableBackendSG,
 		disableRestrictedSGRules: disableRestrictedSGRules,
+		stackGlobalCache:         map[core.StackID]core.Stack{},
+		client:                   k8sClient,
 	}
 }
 
@@ -80,6 +91,8 @@ type defaultModelBuilder struct {
 	enableBackendSG          bool
 	disableRestrictedSGRules bool
 
+	stackGlobalCache map[core.StackID]core.Stack
+
 	clusterName         string
 	vpcID               string
 	defaultTags         map[string]string
@@ -87,10 +100,64 @@ type defaultModelBuilder struct {
 	defaultSSLPolicy    string
 	defaultTargetType   elbv2model.TargetType
 	enableIPTargetType  bool
+
+	client client.Client
+
+	initialized bool
+	lock        sync.RWMutex
 }
 
 func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, bool, error) {
-	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(service)))
+	// Initialize the global cache if not initialized
+	if !b.initialized {
+		// if not initialized, we need to build the global cache based on existing services
+		var serviceList corev1.ServiceList
+		if err := b.client.List(ctx, &serviceList); err != nil {
+			return nil, nil, false, err
+		}
+		for _, svc := range serviceList.Items {
+			if svc.Annotations[LoadBalancerStackKey] != "" && svc.DeletionTimestamp.IsZero() {
+				stackID := core.StackID(types.NamespacedName{
+					Namespace: "stack",
+					Name:      svc.Annotations[LoadBalancerStackKey],
+				})
+				if b.stackGlobalCache[stackID] == nil {
+					b.lock.Lock()
+					b.stackGlobalCache[stackID] = core.NewDefaultStack(stackID)
+					b.lock.Unlock()
+				}
+				b.lock.Lock()
+				b.stackGlobalCache[stackID].AddService(&svc)
+				b.lock.Unlock()
+			}
+		}
+		b.initialized = true
+	}
+
+	// For each stack ID, if we found the stack annotation, this means the service will be sharing the same stack with other services
+	// If so, we should reuse the same stack in the cache so that we can reuse the load balancer with shared listeners
+	stackID := core.StackID(k8s.NamespacedName(service))
+	var stack core.Stack
+	stack = core.NewDefaultStack(stackID)
+	if service.Annotations[LoadBalancerAllocatingPortKey] == "true" {
+		// service will be allocated to a stack with shared loadbalancer
+		if service.Annotations[LoadBalancerStackKey] == "" {
+			return nil, nil, false, errors.Errorf("service %v/%v is waiting to allocated for a stack", service.Namespace, service.Name)
+		}
+		stackID = core.StackID(types.NamespacedName{
+			Namespace: "stack",
+			Name:      service.Annotations[LoadBalancerStackKey],
+		})
+		if b.stackGlobalCache[stackID] == nil {
+			s := core.NewDefaultStack(stackID)
+			b.lock.Lock()
+			b.stackGlobalCache[stackID] = s
+			b.lock.Unlock()
+		}
+		b.lock.RLock()
+		stack = b.stackGlobalCache[stackID]
+		b.lock.RUnlock()
+	}
 	task := &defaultModelBuildTask{
 		clusterName:              b.clusterName,
 		vpcID:                    b.vpcID,
@@ -221,13 +288,63 @@ func (t *defaultModelBuildTask) run(ctx context.Context) error {
 				return errors.Errorf("deletion_protection is enabled, cannot delete the service: %v", t.service.Name)
 			}
 		}
+
+		t.cleanupStackWithRemovingService()
 		return nil
 	}
+	t.stack.AddService(t.service)
 	err := t.buildModel(ctx)
 	return err
 }
 
+// When service is deleted, update resources in the stack to make sure things are cleaned up properly.
+func (t *defaultModelBuildTask) cleanupStackWithRemovingService() {
+	for _, port := range t.service.Spec.Ports {
+		t.stack.RemoveResource(graph.ResourceUID{
+			ResID:   fmt.Sprintf("%v", port.NodePort),
+			ResType: reflect.TypeOf(&elbv2model.Listener{}),
+		})
+		svcPort := intstr.FromInt(int(port.Port))
+		tgResourceID := t.buildTargetGroupResourceID(k8s.NamespacedName(t.service), svcPort)
+		var targetGroups []*elbv2model.TargetGroup
+		var targetGroupBindingResources []*elbv2model.TargetGroupBindingResource
+		t.stack.ListResources(&targetGroups)
+		t.stack.ListResources(&targetGroupBindingResources)
+		for _, tg := range targetGroups {
+			if tg.ID() == tgResourceID {
+				t.stack.RemoveResource(graph.ResourceUID{
+					ResID:   tg.ID(),
+					ResType: reflect.TypeOf(tg),
+				})
+			}
+		}
+		for _, tgBinding := range targetGroupBindingResources {
+			if tgBinding.ID() == tgResourceID {
+				t.stack.RemoveResource(graph.ResourceUID{
+					ResID:   tgBinding.ID(),
+					ResType: reflect.TypeOf(tgBinding),
+				})
+			}
+		}
+	}
+	// Delete the load balancer if there is no listener left.
+	var resLSs []*elbv2model.Listener
+	t.stack.ListResources(&resLSs)
+	if len(resLSs) == 0 {
+		t.stack.RemoveResource(graph.ResourceUID{
+			ResID:   "LoadBalancer",
+			ResType: reflect.TypeOf(&elbv2model.LoadBalancer{}),
+		})
+		t.loadBalancer = nil
+	}
+	t.stack.RemoveService(t.service)
+}
+
 func (t *defaultModelBuildTask) buildModel(ctx context.Context) error {
+	// always lock the stack building models. Since stack can be accessed by multiple goroutines from multiple service reconciliation loops,
+	// make sure only one goroutine is building the model at a time to guarantee thread safety.
+	t.stack.Lock()
+	defer t.stack.Unlock()
 	scheme, err := t.buildLoadBalancerScheme(ctx)
 	if err != nil {
 		return err
@@ -261,4 +378,15 @@ func (t *defaultModelBuildTask) getDeletionProtectionViaAnnotation(svc corev1.Se
 		return deletionProtectionEnabled, nil
 	}
 	return false, nil
+}
+
+func (t *defaultModelBuildTask) stackID() core.StackID {
+	stackID := core.StackID(k8s.NamespacedName(t.service))
+	if t.service.Annotations[LoadBalancerStackKey] != "" {
+		stackID = core.StackID(types.NamespacedName{
+			Namespace: "stack",
+			Name:      t.service.Annotations[LoadBalancerStackKey],
+		})
+	}
+	return stackID
 }

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -6417,7 +6417,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			}
 			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, "vpc-xxx", trackingProvider, elbv2TaggingManager, ec2Client, featureGates,
 				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", defaultTargetType, enableIPTargetType, serviceUtils,
-				backendSGProvider, sgResolver, tt.enableBackendSG, tt.disableRestrictedSGRules)
+				backendSGProvider, sgResolver, tt.enableBackendSG, tt.disableRestrictedSGRules, nil)
 			ctx := context.Background()
 			stack, _, _, err := builder.Build(ctx, tt.svc)
 			if tt.wantError {

--- a/pkg/service/service_utils.go
+++ b/pkg/service/service_utils.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
@@ -14,6 +16,8 @@ type ServiceUtils interface {
 
 	// IsServicePendingFinalization returns true if the service contains the aws-load-balancer-controller finalizer
 	IsServicePendingFinalization(service *corev1.Service) bool
+
+	GetServiceStackName(service *corev1.Service) string
 }
 
 func NewServiceUtils(annotationsParser annotations.Parser, serviceFinalizer string, loadBalancerClass string,
@@ -59,6 +63,13 @@ func (u *defaultServiceUtils) IsServiceSupported(service *corev1.Service) bool {
 		}
 	}
 	return u.checkAWSLoadBalancerTypeAnnotation(service)
+}
+
+func (u *defaultServiceUtils) GetServiceStackName(service *corev1.Service) string {
+	if service.Annotations[LoadBalancerStackKey] != "" {
+		return fmt.Sprintf("k8s-%.8s", service.Annotations[LoadBalancerStackKey])
+	}
+	return ""
 }
 
 func (u *defaultServiceUtils) checkAWSLoadBalancerTypeAnnotation(service *corev1.Service) bool {


### PR DESCRIPTION
This PR adds ability to configure services to share load balancers for different listeners. The purpose of this is to reduce cost when bring NLB for service loadbalancer, while one service will provision one dedicated NLB. 

There are two major changes for the implemetation:
1. A controller that watches services, and allocate service to a "stack". A "stack" contains virtual resources like NLB, listeners.
2. Support multiple services sharing "stack". This is done through global in-memory cache where multiple services can be allocated to one virtual stack, with shared LB and different listener for ports in order to share resources.