### PR TITLE
Add protocol to service.status

### DIFF
--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -309,7 +309,8 @@ func (r *serviceReconciler) updateServiceStatus(ctx context.Context, lbDNS strin
 		if svc.Annotations[service.LoadBalancerAllocatingPortKey] == "true" {
 			for _, port := range svc.Spec.Ports {
 				ingress.Ports = append(ingress.Ports, corev1.PortStatus{
-					Port: port.NodePort,
+					Port:     port.NodePort,
+					Protocol: port.Protocol,
 				})
 			}
 		}


### PR DESCRIPTION
This pr adds protocol to status so that runtime have a way to tell the protocol and generate right endpoints.